### PR TITLE
Payment Fix

### DIFF
--- a/mac-homepage/script.js
+++ b/mac-homepage/script.js
@@ -166,8 +166,6 @@ document.addEventListener('DOMContentLoaded', () => {
 document.addEventListener('DOMContentLoaded', () => {
     const registrationForm = document.getElementById('registrationForm');
     const paymentMessage = document.getElementById('payment-message');
-    const stripe = Stripe('pk_live_51PfFrHRrYAI1t8kM4xYcsyXyVjYCMBEc2YyYxV0m0jY1kP9jZ0g1bW8lX8hYqX8kZ7jZ6kZ5jZ4iY3hX2gA00l6iI7oY2'); // Ersetze dies mit deinem tatsächlichen Public Key
-
     if (registrationForm) {
         registrationForm.addEventListener('submit', async (event) => {
             event.preventDefault();

--- a/mac-homepage/script.js
+++ b/mac-homepage/script.js
@@ -204,21 +204,14 @@ document.addEventListener('DOMContentLoaded', () => {
                     return;
                 }
 
-                const session = await response.json();
-                console.log('Stripe-Session-Response:', session); // Debug-Ausgabe
-                if (!session.id) {
-                    paymentMessage.textContent = session.error || 'Fehler: Keine Session-ID erhalten.';
+                const sessionData = await response.json();
+                if (!sessionData.url) {
+                    paymentMessage.textContent = 'Fehler: Keine URL für die Bezahlseite erhalten.';
                     return;
                 }
-                // 2. Redirect to Stripe Checkout
-                const { error } = await stripe.redirectToCheckout({
-                    sessionId: session.id,
-                });
+                // 2. Redirect to the Stripe Checkout page
+                window.location.href = sessionData.url;
 
-                if (error) {
-                    paymentMessage.textContent = error.message;
-                    console.error('Stripe error:', error);
-                }
             } catch (error) {
                 paymentMessage.textContent = 'Ein unerwarteter Fehler ist aufgetreten.';
                 console.error('Client-side error:', error);


### PR DESCRIPTION
This pull request updates the payment processing logic in the `mac-homepage/script.js` file to simplify the workflow and remove the dependency on the Stripe library. The changes streamline the redirection to the Stripe Checkout page and improve error handling.

### Payment processing updates:

* Removed the initialization of the Stripe library (`Stripe('pk_live_...')`) and its associated usage for redirecting to the Checkout page. Instead, the code now directly uses the `window.location.href` property to redirect the user to the URL provided in the session data. [[1]](diffhunk://#diff-edfe8249692c65290d92daf0e7af59f2d4c1eff8fd2518803c7f46a1a48cb49cL169-L170) [[2]](diffhunk://#diff-edfe8249692c65290d92daf0e7af59f2d4c1eff8fd2518803c7f46a1a48cb49cL207-L221)

* Updated error handling to display a more specific error message when the session data does not include a valid URL for the payment page.