### PR TITLE
Replaced Mojang API with PlayerDB API

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -156,16 +156,16 @@ export default {
                 });
             }
 
-            // Mojang API: Username -> UUID
+            // PlayerDB API: Username -> UUID
             let minecraftUuid;
             try {
-                const mojangRes = await fetch(`https://api.mojang.com/users/profiles/minecraft/${encodeURIComponent(minecraftUsername)}`);
-                if (!mojangRes.ok) throw new Error("Mojang API Fehler");
-                const mojangData = await mojangRes.json();
-                minecraftUuid = mojangData.id;
+                const playerdbRes = await fetch(`https://playerdb.co/api/player/minecraft/${encodeURIComponent(minecraftUsername)}`);
+                if (!playerdbRes.ok) throw new Error("PlayerDB API Fehler");
+                const playerdbData = await playerdbRes.json();
+                minecraftUuid = playerdbData?.data?.player?.id;
                 if (!minecraftUuid) throw new Error("UUID nicht gefunden");
             } catch (err) {
-                return new Response(JSON.stringify({ error: 'Ungültiger Minecraft Username oder Mojang API Fehler' }), {
+                return new Response(JSON.stringify({ error: 'Ungültiger Minecraft Username oder PlayerDB API Fehler' }), {
                     status: 400,
                     headers: { 'Content-Type': 'application/json' }
                 });


### PR DESCRIPTION
This pull request updates the `worker.js` file to switch from using the Mojang API to the PlayerDB API for converting Minecraft usernames to UUIDs. The most important changes include replacing the API endpoint, adjusting the response handling, and updating error messages.

### API Integration Update:
* Replaced the Mojang API endpoint with the PlayerDB API endpoint for fetching Minecraft UUIDs (`https://playerdb.co/api/player/minecraft/`).
* Updated the response handling to match the PlayerDB API's response structure, specifically accessing `playerdbData?.data?.player?.id` for the UUID.
* Modified error messages to reflect the switch from "Mojang API" to "PlayerDB API" in both the code comments and the error response.